### PR TITLE
Improved serial buffering

### DIFF
--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -62,7 +62,7 @@ class LocalDevice(object):
             data = ser.read(i)
             i = data.find(b"\r")
             if i >= 0:
-                if self.buffer[i+1] == b"\n":
+                if len(self.buffer) > (i+1) and self.buffer[i+1] == b"\n":
                     i += 1
                 r = self.buffer + data[:i+1]
                 self.buffer[0:] = data[i+1:]

--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -51,7 +51,7 @@ class LocalDevice(object):
         self.listening = True
         i = self.buffer.find(b"\r")
         if i >= 0:
-            if self.buffer[i+1] == b"\n":
+            if len(self.buffer) > (i+1) and self.buffer[i+1] == b"\n":
                 i += 1
             r = self.buffer[:i+1]
             self.buffer = self.buffer[i+1:]

--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -49,28 +49,21 @@ class LocalDevice(object):
         """
         ser = self.serial_port
         self.listening = True
-        i = self.buffer.find(b"\r")
-        if i >= 0:
-            if len(self.buffer) > (i+1) and self.buffer[i+1] == b"\n":
-                i += 1
-            r = self.buffer[:i+1]
-            self.buffer = self.buffer[i+1:]
-            yield r.hex()
 
         while self.listening:
-            i = max(1, min(2048, ser.in_waiting))
-            data = ser.read(i)
-            i = data.find(b"\r")
-            if i >= 0:
+            i = self.buffer.find(b"\r")
+            while i >= 0:
                 if len(self.buffer) > (i+1) and self.buffer[i+1] == b"\n":
                     i += 1
-                r = self.buffer + data[:i+1]
-                self.buffer[0:] = data[i+1:]
+                r = self.buffer[:i+1]
+                self.buffer = self.buffer[i+1:]
                 hex_message = r.hex()
                 self._last_message = hex_message
                 yield hex_message
-            else:
-                self.buffer.extend(data)
+                i = self.buffer.find(b"\r")
+            i = max(1, min(2048, ser.in_waiting))
+            data = ser.read(i)
+            self.buffer.extend(data)
 
         self.serial_port.close()
 

--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -51,6 +51,8 @@ class LocalDevice(object):
         self.listening = True
         i = self.buffer.find(b"\r")
         if i >= 0:
+            if self.buffer[i+1] == b"\n":
+                i += 1
             r = self.buffer[:i+1]
             self.buffer = self.buffer[i+1:]
             yield r.hex()
@@ -60,6 +62,8 @@ class LocalDevice(object):
             data = ser.read(i)
             i = data.find(b"\r")
             if i >= 0:
+                if self.buffer[i+1] == b"\n":
+                    i += 1
                 r = self.buffer + data[:i+1]
                 self.buffer[0:] = data[i+1:]
                 hex_message = r.hex()

--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -53,7 +53,7 @@ class LocalDevice(object):
         while self.listening:
             i = self.buffer.find(b"\r")
             while i >= 0:
-                if len(self.buffer) > (i+1) and self.buffer[i+1] == b"\n":
+                if len(self.buffer) > (i+1) and self.buffer[i+1:i+2] == b"\n":
                     i += 1
                 r = self.buffer[:i+1]
                 self.buffer = self.buffer[i+1:]

--- a/dweet2ser/local_device.py
+++ b/dweet2ser/local_device.py
@@ -61,6 +61,7 @@ class LocalDevice(object):
                 self._last_message = hex_message
                 yield hex_message
                 i = self.buffer.find(b"\r")
+            time.sleep(.1)
             i = max(1, min(2048, ser.in_waiting))
             data = ser.read(i)
             self.buffer.extend(data)


### PR DESCRIPTION
Changes serial reading logic to separate messages by b"\r" or b"\r\n", to follow the standards of FIS homologated timing devices. Will probably cause unexpected behavior with other serial devices.